### PR TITLE
mouseDrag

### DIFF
--- a/libs/events.js
+++ b/libs/events.js
@@ -272,13 +272,28 @@ events.prototype.afterBattle = function(enemyId) {
                     {'content': '啊，我怎么被封印了！\n能量只剩下一成了！', 'id': 'fairy'}
                 ]);
                 // core.drawTip("触发仙子封印");
+                core.clearContinueAutomaticRoute();
+                return;
             }
         }
         // 打败仙子
         if (enemyId == 'fairy') {
             core.events.win();
+            core.clearContinueAutomaticRoute();
+            return;
         }
     }
+
+
+    //继续行走
+    core.continueAutomaticRoute();
+}
+
+/****** 开完门 ******/
+events.prototype.afterOpenDoor = function(doorId) {
+
+    //继续行走
+    core.continueAutomaticRoute();
 }
 
 /****** 经过路障 ******/

--- a/libs/ui.js
+++ b/libs/ui.js
@@ -1,0 +1,109 @@
+function ui() {
+
+}
+
+ui.prototype.init = function () {
+    if(main.dom.data.addEventListener){
+        main.dom.data.addEventListener('DOMMouseScroll',main.ui.scrollFunc,false);
+    }//IE
+    main.dom.data.onmousewheel=main.ui.scrollFunc;//Opera/Chrome/Safari
+
+    this.holdingPath = 0;
+    this.stepPostfix = [];
+    this.mouseOutCheck = 1;
+}
+
+main.instance.ui = new ui();
+
+ui.prototype.fillPos = function (pos) {
+    core.canvas.ui.lineWidth = 0;
+    core.canvas.ui.fillStyle='#bfbfbf';
+    core.canvas.ui.fillRect(pos.x*32+12,pos.y*32+12,8,8);
+}
+
+ui.prototype.clearStepPostfix = function () {
+    if(main.ui.mouseOutCheck >0){
+        main.ui.mouseOutCheck--;
+        window.setTimeout(main.ui.clearStepPostfix,1000);
+        return;
+    }
+    main.ui.holdingPath=0;
+    if(main.ui.stepPostfix.length){
+        main.ui.stepPostfix=[];
+        core.canvas.ui.clearRect(0, 0, 416,416);
+        core.canvas.ui.restore();
+    }
+    //这个函数内的this是window
+}//用于鼠标移出canvas时的自动清除状态
+
+ui.prototype.ondown = function (x ,y) {
+    if (!core.status.played || core.status.lockControl) {
+        main.core.onclick(x, y, []);
+        return;
+    }
+    this.holdingPath=1;
+    this.mouseOutCheck =1;
+    window.setTimeout(main.ui.clearStepPostfix);
+    core.canvas.ui.save();
+    core.canvas.ui.clearRect(0, 0, 416,416);
+    var pos={'x':x,'y':y}
+    this.stepPostfix=[];
+    this.stepPostfix.push(pos);
+    this.fillPos(pos);
+}
+
+ui.prototype.onmove = function (x ,y) {
+    if (this.holdingPath==0){return;}
+    this.mouseOutCheck =1;
+    var pos={'x':x,'y':y};
+    var pos0=this.stepPostfix[this.stepPostfix.length-1];
+    var directionDistance=[pos.y-pos0.y,pos0.x-pos.x,pos0.y-pos.y,pos.x-pos0.x];
+    var max=0,index=4;
+    for(var ii=0;ii<4;ii++){
+        if(directionDistance[ii]>max){
+            index=ii;
+            max=directionDistance[ii];
+        }
+    }
+    pos=[{'x':0,'y':1},{'x':-1,'y':0},{'x':0,'y':-1},{'x':1,'y':0},false][index]
+    if(pos){
+        pos.x+=pos0.x;
+        pos.y+=pos0.y;
+        this.stepPostfix.push(pos);
+        this.fillPos(pos);
+    }
+}
+
+ui.prototype.onup = function () {
+    this.holdingPath=0;
+    if(this.stepPostfix.length){
+        var stepPostfix = [];
+        var direction={'0':{'1':'down','-1':'up'},'-1':{'0':'left'},'1':{'0':'right'}};
+        for(var ii=1;ii<this.stepPostfix.length;ii++){
+            var pos0 = this.stepPostfix[ii-1];
+            var pos = this.stepPostfix[ii];
+            stepPostfix.push({'direction': direction[pos.x-pos0.x][pos.y-pos0.y], 'x': pos.x, 'y': pos.y});
+        }
+        var posx=this.stepPostfix[0].x;
+        var posy=this.stepPostfix[0].y;
+        this.stepPostfix=[];
+        core.canvas.ui.clearRect(0, 0, 416,416);
+        core.canvas.ui.restore();
+        main.core.onclick(posx,posy,stepPostfix);
+        //posx,posy是之前寻路的目标点,stepPostfix是后续的移动
+    }
+}
+
+ui.prototype.scrollFunc = function(e) {
+    var direct=0;
+    if(e.wheelDelta){//IE/Opera/Chrome
+        direct=Math.sign(e.wheelDelta);
+    }else if(e.detail){//Firefox
+        direct=Math.sign(e.detail);
+    }
+    main.core.onmousewheel(direct);
+}
+
+
+
+

--- a/main.js
+++ b/main.js
@@ -31,8 +31,8 @@ function main() {
     // console.log('加载游戏容器和开始界面dom对象完成 如下');
     // console.log(this.dom);
     this.loadList = [
-        'items.min', 'icons.min', 'maps.min', 'enemys.min', 'events.min',
-        'npcs.min', 'data.min', 'core'
+        'items', 'icons', 'maps', 'enemys', 'events',
+        'npcs', 'data', 'core', 'ui'
     ];
     // console.log('加载js文件列表加载完成' + this.loadList);
     this.images = [
@@ -73,6 +73,7 @@ function main() {
     // console.log('存储实例变量已声明');
     this.canvas = {};
     // console.log('存储canvas变量已声明');
+    this.ui={};//存放与游戏数据无关的ui变量和函数
     //console.log('初始数据已声明');
 }
 
@@ -90,7 +91,7 @@ main.prototype.init = function () {
             // end with -min
             if (name.indexOf(".min")==name.length-4)
                 name=name.substring(0, name.length-4);
-            if (name === 'core') {
+            if (name === 'core' || name === 'ui') {
                 continue;
             }
             main[name].init(main.dom);
@@ -100,6 +101,7 @@ main.prototype.init = function () {
         main.core.init(main.dom, main.statusBar, main.canvas, main.images, main.sounds, coreData);
         //console.log('core函数对象初始化完成');
         main.core.resize(main.dom.body.clientWidth, main.dom.body.clientHeight);
+        main.ui.init();
         //console.log('main函数对象初始化完成');
     });
 }
@@ -182,7 +184,20 @@ main.dom.data.onmousedown = function (e) {
     var loc = main.core.getClickLoc(e.clientX, e.clientY);
     if (loc==null) return;
     var x = parseInt(loc.x / loc.size), y = parseInt(loc.y / loc.size);
-    main.core.onclick(x, y);
+    //main.core.onclick(x, y, []);
+    main.ui.ondown(x,y);
+}
+
+main.dom.data.onmousemove = function (e) {
+    e.stopPropagation();
+    var loc = main.core.getClickLoc(e.clientX, e.clientY);
+    if (loc==null) return;
+    var x = parseInt(loc.x / loc.size), y = parseInt(loc.y / loc.size);
+    main.ui.onmove(x,y);
+}
+
+main.dom.data.onmouseup = function () {
+    main.ui.onup();
 }
 
 main.dom.data.ontouchstart = function (e) {
@@ -190,7 +205,20 @@ main.dom.data.ontouchstart = function (e) {
     var loc = main.core.getClickLoc(e.targetTouches[0].clientX, e.targetTouches[0].clientY);
     if (loc==null) return;
     var x = parseInt(loc.x / loc.size), y = parseInt(loc.y / loc.size);
-    main.core.onclick(x, y);
+    //main.core.onclick(x, y, []);
+    main.ui.ondown(x,y);
+}
+
+main.dom.data.ontouchmove = function (e) {
+    e.preventDefault();
+    var loc = main.core.getClickLoc(e.targetTouches[0].clientX, e.targetTouches[0].clientY);
+    if (loc==null) return;
+    var x = parseInt(loc.x / loc.size), y = parseInt(loc.y / loc.size);
+    main.ui.onmove(x,y);
+}
+
+main.dom.data.ontouchend = function () {
+    main.ui.onup();
 }
 
 main.statusBar.image.book.onclick = function () {


### PR DESCRIPTION
```
在[mota-yikongjian] 31commits的基础上修改/增加了3块
//1 : 寻路算法绕熔岩血瓶
//2 : 楼层传送器的鼠标滚轮支持
其他: 对于鼠标拖拽的支持
----
目前应该没有bug了,
修改了[main.js,core.js,events.js],
增加了ui.js,
需要重新格式化(逗号等号前后的空格之类的,以及把~~替换成parseInt)
=======================
+ :增加了此语句/函数/变量
+-:修改了此函数/变量
========main.js========

+-this.loadList
  增加了'ui'

+-main.prototype.init
  在core初始化之后初始化main.ui

+-main.dom.data.onmousedown = function (e)

+ main.dom.data.onmousemove = function (e)

+ main.dom.data.onmouseup = function ()

+-main.dom.data.ontouchstart = function (e)

+ main.dom.data.ontouchmove = function (e)

+ main.dom.data.ontouchend = function ()

========ui.js========

+ ui.prototype.scrollFunc = function(e)//2
  获取鼠标滚轮滚动方向并传递给core.prototype.onmousewheel

+ ui.prototype.fillPos = function (pos)
  在指定位置画一个小正方形

+ ui.holdingPath
  当前是否在画线
+ ui.stepPostfix
+ ui.mouseOutCheck
  用于检测鼠标或手指是否被移出区域

+ ui.prototype.clearStepPostfix = function ()
  鼠标或手指移出区域一秒后清除状态

+ ui.prototype.ondown = function (x ,y)
  得到自动寻路的起点位置,标记开始画线

+ ui.prototype.onmove = function (x ,y)
  跟随鼠标或手指画线

+ ui.prototype.onup = function ()
  把线路转化为游戏数据,调用main.core.onclick(posx,posy,stepPostfix);

========core.js========

+ core.prototype.idEndWith = function (x, y, idStr)//1
  查找core.status.thisMap.blocks中x,y位置的事件id是否以idStr结尾

core.prototype.automaticRoute://1
  +-绕熔岩绕血瓶
  实现熔岩视为100步血瓶视为20步的自动寻路

+ core.prototype.onmousewheel = function (direct)//2
  接受鼠标滚轮滚动方向,当处于楼层传送器界面时切换显示的楼层

core.prototype.onclick:
  +-参数变为(x, y, stepPostfix)

  +-core.setAutomaticRoute(x, y, stepPostfix);

core.prototype.setAutomaticRoute:
  +-参数变为(destX, destY, stepPostfix)

  + moveStep=moveStep.concat(stepPostfix);

core.prototype.openDoor:
  + core.status.moveStepBeforeStop
    在core.stopAutomaticRoute();前先把未走完的core.status.autoStepRoutes存下来

  +-当无法打开门时:
    + core.prototype.clearContinueAutomaticRoute();

  + core.events.afterOpenDoor(id);

core.prototype.battle:
  + core.status.moveStepBeforeStop
    在core.stopAutomaticRoute();前先把未走完的core.status.autoStepRoutes存下来

  +-当打不过怪物时:
    + core.prototype.clearContinueAutomaticRoute();

+ core.prototype.continueAutomaticRoute = function ()
  继续走完之前存的moveStep

+ core.prototype.clearContinueAutomaticRoute = function ()
  清空走完之前存的moveStep

core.prototype.stopAutomaticRoute:
  +-当有未完成的路线时不清空core.canvas.ui

core.prototype.setHeroMoveTriggerInterval:
  +-if (noPass) {:
    + core.status.moveStepBeforeStop=[];
========events.js========
events.prototype.afterBattle:
  + core.prototype.clearContinueAutomaticRoute();return;
    希望不继续走未完成的路线的场合,在对应事件末尾加core.prototype.clearContinueAutomaticRoute();return;

+ events.prototype.afterOpenDoor = function(doorId)
  开完门后继续走未完成的路线,这里也可以添加开门有关的谜题
```